### PR TITLE
Faster Deployment by using pre-built binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,34 +10,33 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        path: temp_md
-    - name: Checkout linked blog starter repo
-      uses: actions/checkout@v3
-      with:
-        path: temp_blog
-        repository: ${{ env.BLOG_REPO }}
-    - name: Install Rust / cargo
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-    - name: Install and run obsidian-export
-      run: |
-        cargo install obsidian-export
-        rm -rf temp_blog/common_md && mkdir temp_blog/common_md
-        ~/.cargo/bin/obsidian-export ./temp_md/${{ env.PUBLISH_DIR }} temp_blog/common_md
-    - name: Move blog dir to currDir
-      run: |
-        cp -r temp_blog/. .
-        rm -rf temp_blog
-        rm -rf temp_md
-    - name: Deploy Vercel
-      uses: amondnet/vercel-action@v20
-      with:
-        # TODO: Update Github Secrets with values
-        vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
-        vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  # Required
-        vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }} # Required 
-        vercel-args: '--prod' #Optional
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: temp_md
+      - name: Checkout linked blog starter repo
+        uses: actions/checkout@v3
+        with:
+          path: temp_blog
+          repository: ${{ env.BLOG_REPO }}
+      - name: Install obsidian-export
+        run: |
+          wget https://github.com/zoni/obsidian-export/releases/download/v22.11.0/obsidian-export_Linux-x86_64.bin
+          chmod +x obsidian-export_Linux-x86_64.bin
+      - name: Run obsidian-export
+        run: |
+          rm -rf temp_blog/common_md && mkdir temp_blog/common_md
+          ./obsidian-export_Linux-x86_64.bin ./temp_md/${{ env.PUBLISH_DIR }} temp_blog/common_md
+      - name: Move blog dir to currDir
+        run: |
+          cp -r temp_blog/. .
+          rm -rf temp_blog
+          rm -rf temp_md
+      - name: Deploy Vercel
+        uses: amondnet/vercel-action@v20
+        with:
+          # TODO: Update Github Secrets with values
+          vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }} # Required
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }} # Required
+          vercel-args: "--prod" #Optional


### PR DESCRIPTION
Hey, I was using your template and noticed that the deployments take ~2.5 mins to complete. I saw you are installing `obsidian-export` with cargo, which takes ~1 min, (building from source).

If you want a speedier deployment, you can download the pre-built linux binary instead (takes about 1-2 seconds) and skip the `Install Rust / cargo` step and massively speeding up the installation of `obsidian-export`

<img width="1312" alt="Screenshot 2023-07-19 at 23 16 52" src="https://github.com/matthewwong525/linked-blog-starter-md/assets/74211630/508d6d7c-3d0f-4793-9637-5c46e3d6e0ab">

This is an example of the speedup you can get by doing that
